### PR TITLE
Added discovery_api to the list of targets

### DIFF
--- a/endpoints/dev.yaml
+++ b/endpoints/dev.yaml
@@ -18,6 +18,7 @@ extraScrapeConfigs: |
         - https://streams.dev.internal.smartcolumbusos.com/socket/healthcheck
         - https://www.dev-smartos.com
         - https://discovery.dev.internal.smartcolumbusos.com
+        - https://data.dev.internal.smartcolumbusos.com/
 
     relabel_configs:
       - source_labels: [__address__]

--- a/endpoints/dev.yaml
+++ b/endpoints/dev.yaml
@@ -18,7 +18,7 @@ extraScrapeConfigs: |
         - https://streams.dev.internal.smartcolumbusos.com/socket/healthcheck
         - https://www.dev-smartos.com
         - https://discovery.dev.internal.smartcolumbusos.com
-        - https://data.dev.internal.smartcolumbusos.com
+        - https://data.dev.internal.smartcolumbusos.com/healthcheck
 
     relabel_configs:
       - source_labels: [__address__]

--- a/endpoints/dev.yaml
+++ b/endpoints/dev.yaml
@@ -18,7 +18,7 @@ extraScrapeConfigs: |
         - https://streams.dev.internal.smartcolumbusos.com/socket/healthcheck
         - https://www.dev-smartos.com
         - https://discovery.dev.internal.smartcolumbusos.com
-        - https://data.dev.internal.smartcolumbusos.com/
+        - https://data.dev.internal.smartcolumbusos.com
 
     relabel_configs:
       - source_labels: [__address__]


### PR DESCRIPTION
This is part of the card [Alert When Site(s) are Down](https://github.com/smartcolumbusos/scosopedia/issues/179)

In this pr I'm adding discovery_api to the list of target in the dev.yaml to see if that will trigger an alert when discovery_api is down.