### PR TITLE
Added discovery_api to targets in staging

### DIFF
--- a/endpoints/staging.yaml
+++ b/endpoints/staging.yaml
@@ -9,6 +9,7 @@ extraScrapeConfigs: |
         - https://streams.staging.internal.smartcolumbusos.com/socket/healthcheck
         - https://www.staging-smartos.com
         - https://discovery.staging.internal.smartcolumbusos.com
+        - https://data.staging.internal.smartcolumbusos.com/healthcheck
 
     relabel_configs:
       - source_labels: [__address__]


### PR DESCRIPTION
This is part of the card [Alert When Site(s) are Down](https://github.com/smartcolumbusos/scosopedia/issues/179)

In this pr I'm adding discovery_api to the list of target in the staging.yaml to see if that will trigger an alert when discovery_api is down.