### PR TITLE
Added discovery_api to list of targets in prod

### DIFF
--- a/endpoints/prod.yaml
+++ b/endpoints/prod.yaml
@@ -10,6 +10,7 @@ extraScrapeConfigs: |
         - https://www.smartcolumbusos.com/
         - https://survey.smartcolumbusos.com/
         - https://discovery.smartcolumbusos.com
+        - https://data.smartcolumbusos.com/healthcheck
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target


### PR DESCRIPTION
This is part of the card [Alert When Site(s) are Down](https://github.com/smartcolumbusos/scosopedia/issues/179)

In this pr I'm adding discovery_api to the list of targets in the prod.yaml to send an alert when discovery_api is down.