### PR TITLE
Removing Alert and Updating Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,9 +55,6 @@ def deployMonitoringTo(environment) {
             sh("""#!/bin/bash
 
                 helm init --client-only
-                helm repo add new-stable https://charts.helm.sh/stable
-                helm repo add new-incubator https://charts.helm.sh/incubator
-                helm repo update
                 helm dependency update
                 helm upgrade --install prometheus . \
                     --namespace=prometheus \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,7 @@ def deployMonitoringTo(environment) {
                 helm init --client-only
                 helm repo add new-stable https://charts.helm.sh/stable
                 helm repo add new-incubator https://charts.helm.sh/incubator
+                helm repo update
                 helm dependency update
                 helm upgrade --install prometheus . \
                     --namespace=prometheus \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,6 +55,8 @@ def deployMonitoringTo(environment) {
             sh("""#!/bin/bash
 
                 helm init --client-only
+                helm repo add new-stable https://charts.helm.sh/stable
+                helm repo add new-incubator https://charts.helm.sh/incubator
                 helm dependency update
                 helm upgrade --install prometheus . \
                     --namespace=prometheus \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,6 +55,9 @@ def deployMonitoringTo(environment) {
             sh("""#!/bin/bash
 
                 helm init --client-only
+                helm repo rm stable
+                helm repo add stable https://charts.helm.sh/stable
+                helm repo update
                 helm dependency update
                 helm upgrade --install prometheus . \
                     --namespace=prometheus \

--- a/alerts.yaml
+++ b/alerts.yaml
@@ -26,9 +26,6 @@ datasetAlerts:
   - id: 9cf13962-5f81-4dbb-bf98-3b9404050744
     title: "Basic Safety Messages Smart Columbus Connected Vehicle Environment Project"
     interval: 12h
-  - id: 7d22b8b4-2365-4afa-9b7c-e27b39c3e710
-    title: "Basic Safety Messages from US33 Marysville Corridor Project"
-    interval: 25h
   - id: 2c4ead71-9dff-4662-a298-5dec3efef31d
     title: "CoGo GBFS Station Status"
     interval: 25h


### PR DESCRIPTION
- Removing the Marysville BSM alert beccause we no longer receive that data
- Updating the Jenkinsfile to add the new helm stable and incubator repos