### PR TITLE
rule failure alert and typo

### DIFF
--- a/alerts.yaml
+++ b/alerts.yaml
@@ -186,3 +186,12 @@ serverFiles:
           annotations:
             summary: 'Server disk space is below 15%'
             description: 'Low disk space for Server {{ $labels.persistentvolumeclaim }}, only {{ $value | printf "%.2f" }}% space is left.'
+      - name: rule_failure
+        rules:
+        - alert: RuleFailure
+          expr: rate(prometheus_rule_evaluation_failures_total{rule_group=~".*rules.*"}[2m]) > 0
+          labels:
+            severity: warning
+          annotations:
+            summary: 'Prometheus has failed to precalculate one or more metrics'
+            description: 'One of the recording rules defined in Prometheus has failed to execute. This is often due to issues with info metrics, but may have other causes. Look at the rules section of the Prometheus interface for more info.'

--- a/dashboards/pipeline-health.yaml
+++ b/dashboards/pipeline-health.yaml
@@ -40,7 +40,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1607005515948,
+      "iteration": 1611260467014,
       "links": [],
       "panels": [
         {
@@ -127,7 +127,7 @@ data:
               "refId": "A"
             },
             {
-              "expr": "sum(rate(kafka_topic_partition_current_offset{kubernetes_namespace=\"streaming-prime\", topic=~\"(streaming-persisted|streamiing-dead-letters)\"}[2m]) > 0) by (topic)",
+              "expr": "sum(rate(kafka_topic_partition_current_offset{kubernetes_namespace=\"streaming-prime\", topic=~\"(streaming-persisted|streaming-dead-letters)\"}[2m]) > 0) by (topic)",
               "interval": "",
               "legendFormat": "{{topic}}",
               "refId": "B"
@@ -648,7 +648,7 @@ data:
             "overrides": []
           },
           "gridPos": {
-            "h": 8,
+            "h": 9,
             "w": 12,
             "x": 12,
             "y": 16


### PR DESCRIPTION
This alert will fire if precalculated metrics are failing to be calculated. (This can cause the dashboard to look like the world is ending when in fact it is a prometheus issue.)